### PR TITLE
Migrate action to node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'phplint problem matcher'
 author: 'Kristof Hamann'
 description: 'Shows php lint errors as annotation (with file and code line) in GitHub Actions'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'check-square'


### PR DESCRIPTION
due to https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/